### PR TITLE
Entidades de produtores

### DIFF
--- a/app/helpers/admin/enterprises_helper.rb
+++ b/app/helpers/admin/enterprises_helper.rb
@@ -13,5 +13,9 @@ module Admin
     def select_only_item(producers)
       producers.size == 1 ? producers.first.id : nil
     end
+
+    def entity_options
+      YAML.safe_load(File.read(Rails.root.join('config/entities_list.yml')))['entities']
+    end
   end
 end

--- a/app/serializers/api/admin/enterprise_serializer.rb
+++ b/app/serializers/api/admin/enterprise_serializer.rb
@@ -16,7 +16,7 @@ module Api
                  :preferred_invoice_order_by_supplier, :preferred_product_low_stock_display,
                  :visible, :small_farmer_recognition_document,
                  :small_farmer_recognition_document_file_name,
-                 :small_farmer_recognition_document_uploaded_at
+                 :small_farmer_recognition_document_uploaded_at, :entity_name
 
       has_one :owner, serializer: Api::Admin::UserSerializer
       has_many :users, serializer: Api::Admin::UserSerializer

--- a/app/services/permitted_attributes/enterprise.rb
+++ b/app/services/permitted_attributes/enterprise.rb
@@ -35,7 +35,7 @@ module PermittedAttributes
         :show_customer_names_to_suppliers, :preferred_shopfront_product_sorting_method,
         :preferred_invoice_order_by_supplier,
         :preferred_product_low_stock_display,
-        :small_farmer_recognition_document
+        :small_farmer_recognition_document, :entity_name
       ]
     end
   end

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -36,7 +36,7 @@
   .three.columns.alpha
     = f.label :entity_name, t('.entity_name')
   .eight.columns.omega
-    = f.select :entity_name, options_for_select(YAML.load(File.read(Rails.root.join('config/entities_list.yml')))['entities'], @enterprise.entity_name), { include_blank: true }, class: "select2 fullwidth"
+    = f.select :entity_name, options_for_select(entity_options, @enterprise.entity_name), { include_blank: true }, class: "select2 fullwidth"
 
 .row
   .alpha.three.columns

--- a/app/views/admin/enterprises/form/_business_details.html.haml
+++ b/app/views/admin/enterprises/form/_business_details.html.haml
@@ -33,6 +33,12 @@
     = f.text_area :invoice_text, style: "width: 100%; height: 100px;"
 
 .row
+  .three.columns.alpha
+    = f.label :entity_name, t('.entity_name')
+  .eight.columns.omega
+    = f.select :entity_name, options_for_select(YAML.load(File.read(Rails.root.join('config/entities_list.yml')))['entities'], @enterprise.entity_name), { include_blank: true }, class: "select2 fullwidth"
+
+.row
   .alpha.three.columns
     = f.label :terms_and_conditions, t('.terms_and_conditions')
     %i.text-big.icon-question-sign{ "data-controller": "help-modal-link", "data-action": "click->help-modal-link#open", "data-help-modal-link-target-value": "terms_and_conditions_info_modal" }

--- a/config/entities_list.yml
+++ b/config/entities_list.yml
@@ -1,0 +1,4 @@
+---
+entities:
+  - one entity
+  - another entity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -874,6 +874,7 @@ en:
           sort_items_by_supplier_tip: "When enabled, Items will be sorted by supplier name."
           enabled: Enable
           disabled: Disable
+          entity_name: Entity name
         business_address:
           company_legal_name: Company Legal Name
           company_placeholder: Example Inc.

--- a/db/migrate/20220629135005_add_entity_name_to_enterprises.rb
+++ b/db/migrate/20220629135005_add_entity_name_to_enterprises.rb
@@ -1,0 +1,5 @@
+class AddEntityNameToEnterprises < ActiveRecord::Migration[6.1]
+  def change
+    add_column :enterprises, :entity_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_21_230907) do
+ActiveRecord::Schema.define(version: 2022_06_29_135005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema.define(version: 2022_06_21_230907) do
     t.integer "business_address_id"
     t.boolean "show_customer_names_to_suppliers", default: false, null: false
     t.string "visible", limit: 255, default: "public", null: false
+    t.string "entity_name"
     t.index ["address_id"], name: "index_enterprises_on_address_id"
     t.index ["is_primary_producer", "sells"], name: "index_enterprises_on_is_primary_producer_and_sells"
     t.index ["name"], name: "index_enterprises_on_name", unique: true

--- a/spec/system/admin/enterprises_spec.rb
+++ b/spec/system/admin/enterprises_spec.rb
@@ -485,7 +485,7 @@ describe '
           end
           
           choose "enterprise_preferred_shopfront_product_sorting_method_by_category"
-          find("#s2id_autogen7").click
+          find("#s2id_autogen8").click
           find(".select2-result-label", text: "Tricky Taxon").click
           click_button 'Update'
           expect(flash_message).to eq('Enterprise "First Distributor" has been successfully updated!')
@@ -506,7 +506,7 @@ describe '
           end
           
           choose "enterprise_preferred_shopfront_product_sorting_method_by_producer"
-          find("#s2id_autogen8").click
+          find("#s2id_autogen9").click
           find(".select2-result-label", text: "First Supplier").click
           click_button 'Update'
           expect(flash_message).to eq('Enterprise "First Distributor" has been successfully updated!')


### PR DESCRIPTION
Este MR adiciona uma opção para cadastrar um nome de entidade em um produtor.

Por enquanto, sysadmins devem alterar a lista criada no arquivo de configuração para mudar as opções para escolha.

Essa solução deve evoluir, no futuro, para termos um modelo de Entidade que admins possam gerenciar. Então, a lista para cadastro será construída a partir dos nomes salvos no banco de dados.